### PR TITLE
makeActiveDb(); added to the methods getIndexManager() and getSchema()

### DIFF
--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
@@ -298,12 +298,12 @@ public final class OrientGraph implements Graph {
     }
 
     private OIndexManager getIndexManager() {
-		makeActiveDb();
+        makeActiveDb();
         return database.getMetadata().getIndexManager();
     }
 
     private OSchema getSchema() {
-		makeActiveDb();
+        makeActiveDb();
         return database.getMetadata().getSchema();
     }
 

--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraph.java
@@ -298,10 +298,12 @@ public final class OrientGraph implements Graph {
     }
 
     private OIndexManager getIndexManager() {
+		makeActiveDb();
         return database.getMetadata().getIndexManager();
     }
 
     private OSchema getSchema() {
+		makeActiveDb();
         return database.getMetadata().getSchema();
     }
 


### PR DESCRIPTION
We are accessing orientdb with your orientdb-gremlin driver (version 3.2.3.0). Our client is written in C# and we use a modified version of teva (https://github.com/effyteva/CSharpLibraries/tree/master/Teva.Common.Data.Gremlin).

Everything works fine when we initially store data into a new database instance. But when we try to access the database a second time we get the following exception:

[WARN] AbstractEvalOpProcessor - Exception processing a script on request [Reque
stMessage{, requestId=815e910e-2dd2-40dd-a2f2-2fd87d4ad9fa, op='eval', processor
='', args={gremlin=g.V().has(p0,p1).has(T.label,p2).hasNext(), bindings={p0=Full
QualifiedName, p1=SharpMetrics.Domain.Model.Definition.CodeModel, p2=CodeModel},
language=gremlin-groovy}}].
com.orientechnologies.orient.core.exception.ODatabaseException: The database ins
tance is not set in the current thread. Be sure to set it with: ODatabaseRecordThreadLocal.INSTANCE.set(db);
at com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal.get(ODatabaseRecordThreadLocal.java:51)
at com.orientechnologies.orient.core.index.OIndexManagerAbstract.getDatabase(OIndexManagerAbstract.java:421)
at com.orientechnologies.orient.core.index.OIndexManagerAbstract.getServerLocale(OIndexManagerAbstract.java:510)
at com.orientechnologies.orient.core.index.OIndexManagerAbstract.getClassIndexes(OIndexManagerAbstract.java:327)
at com.orientechnologies.orient.core.index.OIndexManagerAbstract.getClassIndexes(OIndexManagerAbstract.java:321)
at com.orientechnologies.orient.core.index.OIndexManagerProxy.getClassIndexes(OIndexManagerProxy.java:137)
at org.apache.tinkerpop.gremlin.orientdb.OrientGraph.getIndexedKeys(OrientGraph.java:308)
at org.apache.tinkerpop.gremlin.orientdb.OrientGraph.getVertexIndexedKeys(OrientGraph.java:340)
at org.apache.tinkerpop.gremlin.orientdb.OrientGraph.getIndexedKeys(OrientGraph.java:318)
at org.apache.tinkerpop.gremlin.orientdb.traversal.step.sideEffect.OrientGraphStep.lambda$findIndex$7(OrientGraphStep.java:155)
at java.lang.Iterable.forEach(Unknown Source)
at org.apache.tinkerpop.gremlin.orientdb.traversal.step.sideEffect.OrientGraphStep.findIndeOrientGraphStep.java:155)
at org.apache.tinkerpop.gremlin.orientdb.traversal.step.sideEffect.OrientGraphStep.elements(OrientGraphStep.java:88)
at org.apache.tinkerpop.gremlin.orientdb.traversal.step.sideEffect.OrientGraphStep.vertices(OrientGraphStep.java:54)
at org.apache.tinkerpop.gremlin.orientdb.traversal.step.sideEffect.OrientGraphStep.lambda$new$0(OrientGraphStep.java:46)
at org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep.processNextStart(GraphStep.java:136)
at org.apache.tinkerpop.gremlin.process.traversal.step.util.AbstractStep.hasNext(AbstractStep.java:143)
at org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversal.hasNext(DefaultTraversal.java:179)
at java_util_Iterator$hasNext.call(Unknown Source)
at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:117)
at Script2.run(Script2.groovy:1)
at org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine.eval(GremlinGroovyScriptEngine.java:619)
at org.apache.tinkerpop.gremlin.groovy.jsr223.GremlinGroovyScriptEngine.eval(GremlinGroovyScriptEngine.java:448)
at javax.script.AbstractScriptEngine.eval(Unknown Source)
at org.apache.tinkerpop.gremlin.groovy.engine.ScriptEngines.eval(ScriptEngines.java:119)
at org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor.lambda$eval$2(GremlinExecutor.java:287)
at java.util.concurrent.FutureTask.run(Unknown Source)
at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
at java.lang.Thread.run(Unknown Source)

To me it  seems that the method
private OIndexManager getIndexManager() {
    return database.getMetadata().getIndexManager();
}

is accessing the database without prior making it "active". So I modified the method into 
private OIndexManager getIndexManager() {  
   makeActive();
   return database.getMetadata().getIndexManager();
}   

After adding these changes the exception is not thrown anymore and I can access the database again.