### PR TITLE
Update OrientGraphFactory.java

### DIFF
--- a/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphFactory.java
+++ b/driver/src/main/java/org/apache/tinkerpop/gremlin/orientdb/OrientGraphFactory.java
@@ -9,7 +9,7 @@ import com.orientechnologies.orient.core.exception.ODatabaseException;
 import com.orientechnologies.orient.core.metadata.schema.OClass;
 import com.orientechnologies.orient.core.metadata.schema.OSchema;
 
-public final class OrientGraphFactory {
+public class OrientGraphFactory {
     public static String ADMIN = "admin";
     protected final String url;
     protected final String user;


### PR DESCRIPTION
Class is no longer final, allows us to overwrite `protected ODatabaseDocumentTx getDatabase(boolean create, boolean open)` and set custom properties on the returned ODatabaseDocumentTx.